### PR TITLE
:hammer: Refactor action declaration pattern

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -25,166 +25,50 @@ export type Actions =
     | SettingsActions
     | ShareActions;
 
-export const enum Types {
-    ASSIGN_INSTANCE_ID = 'ASSIGN_INSTANCE_ID',
-    BECOME_PLAYBACK_MASTER = 'BECOME_PLAYBACK_MASTER',
-    RESIGN_PLAYBACK_MASTER = 'RESIGN_PLAYBACK_MASTER',
-    INSTALL_PLAYBACK_MASTER = 'INSTALL_PLAYBACK_MASTER',
-    CHANGE_DISPLAY_LOGIN_MODAL = 'CHANGE_DISPLAY_LOGIN_MODAL',
-    CHANGE_PARTY_ID = 'CHANGE_PARTY_ID',
-    CHANGE_PARTY_SETTING = 'CHANGE_PARTY_SETTING',
-    CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT = 'CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT',
-    CHANGE_TRACK_SEARCH_INPUT = 'CHANGE_TRACK_SEARCH_INPUT',
-    CHECK_LOGIN_STATUS = 'CHECK_LOGIN_STATUS',
-    TOGGLE_USER_MENU = 'TOGGLE_USER_MENU',
-    REQUIRE_FOLLOW_UP_LOGIN = 'REQUIRE_FOLLOW_UP_LOGIN',
-    CLEANUP_PARTY = 'CLEANUP_PARTY',
-    CREATE_PARTY_Start = 'CREATE_PARTY_START',
-    CREATE_PARTY_Fail = 'CREATE_PARTY_FAIL',
-    EXCHANGE_CODE_Start = 'EXCHANGE_CODE_START',
-    EXCHANGE_CODE_Fail = 'EXCHANGE_CODE_FAIL',
-    FLUSH_QUEUE_Start = 'FLUSH_QUEUE_START',
-    FLUSH_QUEUE_Fail = 'FLUSH_QUEUE_FAIL',
-    FLUSH_QUEUE_Finish = 'FLUSH_QUEUE_FINISH',
-    JOIN_PARTY_Start = 'JOIN_PARTY_START',
-    JOIN_PARTY_Fail = 'JOIN_PARTY_FAIL',
-    INSERT_FALLBACK_PLAYLIST_Start = 'INSERT_FALLBACK_PLAYLIST_START',
-    INSERT_FALLBACK_PLAYLIST_Finish = 'INSERT_FALLBACK_PLAYLIST_FINISH',
-    INSERT_FALLBACK_PLAYLIST_Progress = 'INSERT_FALLBACK_PLAYLIST_PROGRESS',
-    INSERT_FALLBACK_PLAYLIST_Fail = 'INSERT_FALLBACK_PLAYLIST_FAIL',
-    LOAD_PLAYLISTS_Start = 'LOAD_PLAYLISTS_START',
-    LOAD_PLAYLISTS_Fail = 'LOAD_PLAYLISTS_FAIL',
-    LOGOUT = 'LOGOUT',
-    NOTIFY_AUTH_STATUS_KNOWN = 'NOTIFY_AUTH_STATUS_KNOWN',
-    OPEN_PARTY_Fail = 'OPEN_PARTY_FAIL',
-    OPEN_PARTY_Finish = 'OPEN_PARTY_FINISH',
-    OPEN_PARTY_Start = 'OPEN_PARTY_START',
-    PLAYER_ERROR = 'PLAYER_ERROR',
-    PLAYER_INIT_Start = 'PLAYER_INIT_START',
-    PLAYER_INIT_Finish = 'PLAYER_INIT_FINISH',
-    QUEUE_DRAG_Enter = 'QUEUE_DRAG_Enter',
-    QUEUE_DRAG_Over = 'QUEUE_DRAG_Over',
-    QUEUE_DRAG_Drop = 'QUEUE_DRAG_Drop',
-    REQUEST_SET_VOTE = 'REQUEST_SET_VOTE',
-    REMOVE_TRACK = 'REMOVE_TRACK',
-    SEARCH_Start = 'SEARCH_START',
-    SEARCH_Finish = 'SEARCH_FINISH',
-    SEARCH_Fail = 'SEARCH_FAIL',
-    SHARE_PARTY = 'SHARE_PARTY',
-    SHOW_TOAST = 'SHOW_TOAST',
-    HIDE_TOAST = 'HIDE_TOAST',
-    SET_VOTE = 'SET_VOTE',
-    TOGGLE_PLAYBACK_Start = 'TOGGLE_PLAYBACK_START',
-    TOGGLE_PLAYBACK_Finish = 'TOGGLE_PLAYBACK_FINISH',
-    TOGGLE_PLAYBACK_Fail = 'TOGGLE_PLAYBACK_FAIL',
-    TRIGGER_OAUTH_LOGIN = 'TRIGGER_OAUTH_LOGIN',
-    UPDATE_NETWORK_CONNECTION_STATE = 'UPDATE_NETWORK_CONNECTION_STATE',
-    UPDATE_METADATA = 'UPDATE_METADATA',
-    UPDATE_PARTY = 'UPDATE_PARTY',
-    UPDATE_PARTY_NAME = 'UPDATE_PARTY_NAME',
-    UPDATE_TRACKS = 'UPDATE_TRACKS',
-    UPDATE_USER_PLAYLISTS = 'UPDATE_USER_PLAYLISTS',
-    UPDATE_USER_VOTES = 'UPDATE_USER_VOTES',
-    UPDATE_PLAYBACK_STATE = 'UPDATE_PLAYBACK_STATE',
-    SET_PLAYER_COMPATIBILITY = 'SET_PLAYER_COMPATIBILITY',
-    SPOTIFY_SDK_INIT_Finish = 'SPOTIFY_SDK_INIT_FINISH',
-    PLAY = 'PLAY',
-    PAUSE = 'PAUSE',
-}
-
-export interface PayloadAction<T> {
-    payload: T;
-}
-
-export interface ErrorAction extends PayloadAction<Error> {
-    error: true;
-}
-
 export type CommonActions =
-    | AssignInstanceIdAction
-    | QueueDragDropAction
-    | QueueDragEnterAction
-    | QueueDragOverAction
-    | HideToastAction
-    | ShowToastAction;
+    | ReturnType<typeof generateInstanceId>
+    | ReturnType<typeof hideToast>
+    | ReturnType<typeof queueDragDrop>
+    | ReturnType<typeof queueDragEnter>
+    | ReturnType<typeof queueDragOver>
+    | ReturnType<typeof showToast>;
 
-export interface AssignInstanceIdAction extends PayloadAction<string> {
-    type: Types.ASSIGN_INSTANCE_ID;
-}
+export const ASSIGN_INSTANCE_ID = 'ASSIGN_INSTANCE_ID';
+export const HIDE_TOAST = 'HIDE_TOAST';
+export const QUEUE_DRAG_ENTER = 'QUEUE_DRAG_ENTER';
+export const QUEUE_DRAG_OVER = 'QUEUE_DRAG_OVER';
+export const QUEUE_DRAG_DROP = 'QUEUE_DRAG_DROP';
+export const SHOW_TOAST = 'SHOW_TOAST';
 
-export interface QueueDragEnterAction extends PayloadAction<DragData> {
-    type: Types.QUEUE_DRAG_Enter;
-}
+export const queueDragEnter = (event: DragEvent) => ({
+    type: QUEUE_DRAG_ENTER as typeof QUEUE_DRAG_ENTER,
+    payload: { event },
+});
 
-export interface QueueDragOverAction extends PayloadAction<DragData> {
-    type: Types.QUEUE_DRAG_Over;
-}
+export const queueDragOver = (event: DragEvent) => ({
+    type: QUEUE_DRAG_OVER as typeof QUEUE_DRAG_OVER,
+    payload: { event },
+});
 
-export interface QueueDragDropAction extends PayloadAction<DragData> {
-    type: Types.QUEUE_DRAG_Drop;
-}
+export const queueDragDrop = (event: DragEvent) => ({
+    type: QUEUE_DRAG_DROP as typeof QUEUE_DRAG_DROP,
+    payload: { event },
+});
 
-export interface HideToastAction {
-    type: Types.HIDE_TOAST;
-}
+export const generateInstanceId = () => ({
+    type: ASSIGN_INSTANCE_ID as typeof ASSIGN_INSTANCE_ID,
+    payload: String(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)),
+});
 
-export interface LinkData {
-    event: MouseEvent;
-    route: string;
-}
+export const hideToast = () => ({ type: HIDE_TOAST as typeof HIDE_TOAST });
 
-export interface DragData {
-    event: DragEvent;
-}
-
-export interface ShowToastAction extends PayloadAction<ToastData> {
-    type: Types.SHOW_TOAST;
-}
-
-export interface ToastData {
-    duration: number;
-    text: string;
-}
-
-export function queueDragEnter(event: DragEvent): QueueDragEnterAction {
-    return {
-        type: Types.QUEUE_DRAG_Enter,
-        payload: { event },
-    };
-}
-
-export function queueDragOver(event: DragEvent): QueueDragOverAction {
-    return {
-        type: Types.QUEUE_DRAG_Over,
-        payload: { event },
-    };
-}
-
-export function queueDragDrop(event: DragEvent): QueueDragDropAction {
-    return {
-        type: Types.QUEUE_DRAG_Drop,
-        payload: { event },
-    };
-}
-
-export function generateInstanceId(): AssignInstanceIdAction {
-    return {
-        type: Types.ASSIGN_INSTANCE_ID,
-        payload: String(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)),
-    };
-}
-
-export function hideToast(): HideToastAction {
-    return { type: Types.HIDE_TOAST };
-}
-
-export function showToast(text: string, duration: number = 3000): ShowToastAction {
+export const showToast = (text: string, duration: number = 3000) => {
     if (duration < 0) {
         throw new Error("Toast duration < 0");
     }
 
     return {
-        type: Types.SHOW_TOAST,
+        type: SHOW_TOAST as typeof SHOW_TOAST,
         payload: { duration, text },
     };
-}
+};

--- a/src/actions/metadata.ts
+++ b/src/actions/metadata.ts
@@ -4,14 +4,55 @@ import * as SpotifyApi from 'spotify-web-api-js';
 import { FANART_TV_API_KEY } from '../../common.config';
 import { Metadata } from '../state';
 
-import { PayloadAction, Types } from '.';
-
 export type Actions =
-    | UpdateMetadataAction;
+    | ReturnType<typeof updateMetadata>;
 
-export interface UpdateMetadataAction extends PayloadAction<Record<string, Partial<Metadata>>> {
-    type: Types.UPDATE_METADATA;
+export const UPDATE_METADATA = 'UPDATE_METADATA';
+
+export function updateMetadata(
+    meta: Record<string, Metadata> | SpotifyApi.TrackObjectFull[] | Record<string, string[]>,
+) {
+    function isFanartObj(
+        meta: Record<string, Metadata> | Record<string, string[]>,
+    ): meta is Record<string, string[]> {
+        return Object.keys(meta).some(k => Array.isArray(meta[k]));
+    }
+
+    if (Array.isArray(meta)) {
+        const payload: Record<string, Metadata> = {};
+        for (const track of meta) {
+            payload[`spotify-${track.id}`] = {
+                artists: track.artists.map(art => art.name),
+                cover: track.album.images.filter(img => img.width && img.height),
+                durationMs: track.duration_ms,
+                isrc: track.external_ids ? track.external_ids.isrc : undefined,
+                isPlayable: track.is_playable !== false,
+                name: track.name,
+            } as Metadata;
+        }
+
+        return {
+            type: UPDATE_METADATA as typeof UPDATE_METADATA,
+            payload,
+        };
+    } else if (isFanartObj(meta)) {
+        const payload: Record<string, Partial<Metadata>> = {};
+        Object.keys(meta)
+            .forEach(key => payload[key] = { background: meta[key] });
+
+        return {
+            type: UPDATE_METADATA as typeof UPDATE_METADATA,
+            payload,
+        };
+    } else {
+        return {
+            type: UPDATE_METADATA as typeof UPDATE_METADATA,
+            payload: meta,
+        };
+    }
 }
+
+/* Utils */
 
 interface StoredMetadata extends Metadata {
     dateCreated: number;
@@ -214,47 +255,4 @@ export async function getMusicBrainzId(meta: Metadata): Promise<string | null> 
         );
 
     return likeliestArtist ? likeliestArtist.id : null;
-}
-
-export function updateMetadata(
-    meta: Record<string, Metadata> | SpotifyApi.TrackObjectFull[] | Record<string, string[]>,
-): UpdateMetadataAction {
-    function isFanartObj(
-        meta: Record<string, Metadata> | Record<string, string[]>,
-    ): meta is Record<string, string[]> {
-        return Object.keys(meta).some(k => Array.isArray(meta[k]));
-    }
-
-    if (Array.isArray(meta)) {
-        const payload: Record<string, Metadata> = {};
-        for (const track of meta) {
-            payload[`spotify-${track.id}`] = {
-                artists: track.artists.map(art => art.name),
-                cover: track.album.images.filter(img => img.width && img.height),
-                durationMs: track.duration_ms,
-                isrc: track.external_ids ? track.external_ids.isrc : undefined,
-                isPlayable: track.is_playable !== false,
-                name: track.name,
-            } as Metadata;
-        }
-
-        return {
-            type: Types.UPDATE_METADATA,
-            payload,
-        };
-    } else if (isFanartObj(meta)) {
-        const payload: Record<string, Partial<Metadata>> = {};
-        Object.keys(meta)
-            .forEach(key => payload[key] = { background: meta[key] });
-
-        return {
-            type: Types.UPDATE_METADATA,
-            payload,
-        };
-    } else {
-        return {
-            type: Types.UPDATE_METADATA,
-            payload: meta,
-        };
-    }
 }

--- a/src/actions/party-data.ts
+++ b/src/actions/party-data.ts
@@ -2,111 +2,107 @@ import { ConnectionState, Party, PartySettings, Playback, Track } from '../state
 import { requireAuth } from '../util/auth';
 import firebase, { firebaseNS } from '../util/firebase';
 
-import { ErrorAction, PayloadAction, Types } from '.';
-
 export type Actions =
-    | BecomePlaybackMasterAction
-    | CleanupPartyAction
-    | CreatePartyFailAction
-    | CreatePartyStartAction
-    | InstallPlaybackMasterAction
-    | JoinPartyFailAction
-    | JoinPartyStartAction
-    | ResignPlaybackMasterAction
-    | OpenPartyFailAction
-    | OpenPartyFinishAction
-    | OpenPartyStartAction
-    | UpdateNetworkConnectionStateAction
-    | UpdatePartyAction
-    | UpdateTracksAction
-    | UpdateUserVotesAction
-    | UpdatePlaybackStateAction;
+    | ReturnType<typeof becomePlaybackMaster>
+    | ReturnType<typeof cleanupParty>
+    | ReturnType<typeof createPartyFail>
+    | ReturnType<typeof createPartyStart>
+    | ReturnType<typeof installPlaybackMaster>
+    | ReturnType<typeof joinPartyFail>
+    | ReturnType<typeof joinPartyStart>
+    | ReturnType<typeof resignPlaybackMaster>
+    | ReturnType<typeof openPartyFail>
+    | ReturnType<typeof openPartyFinish>
+    | ReturnType<typeof openPartyStart>
+    | ReturnType<typeof updateConnectionState>
+    | ReturnType<typeof updateParty>
+    | ReturnType<typeof updateTracks>
+    | ReturnType<typeof updateUserVotes>
+    | ReturnType<typeof updatePlaybackState>;
 
-export interface BecomePlaybackMasterAction {
-    type: Types.BECOME_PLAYBACK_MASTER;
-}
+export const BECOME_PLAYBACK_MASTER = 'BECOME_PLAYBACK_MASTER';
+export const CLEANUP_PARTY = 'CLEANUP_PARTY';
+export const CREATE_PARTY_FAIL = 'CREATE_PARTY_Fail';
+export const CREATE_PARTY_START = 'CREATE_PARTY_Start';
+export const JOIN_PARTY_FAIL = 'JOIN_PARTY_Fail';
+export const JOIN_PARTY_START = 'JOIN_PARTY_Start';
+export const INSTALL_PLAYBACK_MASTER = 'INSTALL_PLAYBACK_MASTER';
+export const OPEN_PARTY_FAIL = 'OPEN_PARTY_Fail';
+export const OPEN_PARTY_FINISH = 'OPEN_PARTY_Finish';
+export const OPEN_PARTY_START = 'OPEN_PARTY_Start';
+export const RESIGN_PLAYBACK_MASTER = 'RESIGN_PLAYBACK_MASTER';
+export const UPDATE_NETWORK_CONNECTION_STATE = 'UPDATE_NETWORK_CONNECTION_STATE';
+export const UPDATE_PARTY = 'UPDATE_PARTY';
+export const UPDATE_TRACKS = 'UPDATE_TRACKS';
+export const UPDATE_USER_VOTES = 'UPDATE_USER_VOTES';
+export const UPDATE_PLAYBACK_STATE = 'UPDATE_PLAYBACK_STATE';
 
-export interface CleanupPartyAction {
-    type: Types.CLEANUP_PARTY;
-}
+export const becomePlaybackMaster = () => ({ type: BECOME_PLAYBACK_MASTER as typeof BECOME_PLAYBACK_MASTER });
 
-export interface CreatePartyStartAction {
-    type: Types.CREATE_PARTY_Start;
-}
+export const cleanupParty = () => ({ type: CLEANUP_PARTY as typeof CLEANUP_PARTY });
 
-export interface CreatePartyFailAction extends ErrorAction {
-    type: Types.CREATE_PARTY_Fail;
-}
+export const createPartyFail = (err: Error) => ({
+    type: CREATE_PARTY_FAIL as typeof CREATE_PARTY_FAIL,
+    error: true,
+    payload: err,
+});
 
-export interface InstallPlaybackMasterAction {
-    type: Types.INSTALL_PLAYBACK_MASTER;
-}
+export const createPartyStart = () => ({ type: CREATE_PARTY_START as typeof CREATE_PARTY_START });
 
-export interface JoinPartyFailAction extends PayloadAction<Error> {
-    type: Types.JOIN_PARTY_Fail;
-    error: true;
-}
+export const joinPartyFail = (err: Error) => ({
+    type: JOIN_PARTY_FAIL as typeof JOIN_PARTY_FAIL,
+    error: true,
+    payload: err,
+});
 
-export interface JoinPartyStartAction {
-    type: Types.JOIN_PARTY_Start;
-}
+export const joinPartyStart = () => ({ type: JOIN_PARTY_START as typeof JOIN_PARTY_START });
 
-export interface OpenPartyFailAction extends PayloadAction<Error> {
-    type: Types.OPEN_PARTY_Fail;
-    error: true;
-}
+export const installPlaybackMaster = () => ({ type: INSTALL_PLAYBACK_MASTER as typeof INSTALL_PLAYBACK_MASTER });
 
-export interface OpenPartyFinishAction extends PayloadAction<Party> {
-    type: Types.OPEN_PARTY_Finish;
-}
+export const openPartyFail = (err: Error) => ({
+    type: OPEN_PARTY_FAIL as typeof OPEN_PARTY_FAIL,
+    error: true,
+    payload: err,
+});
 
-export interface OpenPartyStartAction extends PayloadAction<string> {
-    type: Types.OPEN_PARTY_Start;
-}
+export const openPartyFinish = (party: Party) => ({
+    type: OPEN_PARTY_FINISH as typeof OPEN_PARTY_FINISH,
+    payload: party,
+});
 
-export interface ResignPlaybackMasterAction {
-    type: Types.RESIGN_PLAYBACK_MASTER;
-}
+export const openPartyStart = (id: string) => ({
+    type: OPEN_PARTY_START as typeof OPEN_PARTY_START,
+    payload: id,
+});
 
-export interface UpdateNetworkConnectionStateAction extends PayloadAction<ConnectionState> {
-    type: Types.UPDATE_NETWORK_CONNECTION_STATE;
-}
+export const resignPlaybackMaster = () => ({ type: RESIGN_PLAYBACK_MASTER as typeof RESIGN_PLAYBACK_MASTER });
 
-export interface UpdatePartyAction extends PayloadAction<Party> {
-    type: Types.UPDATE_PARTY;
-}
+export const updateConnectionState = (isConnected: ConnectionState) => ({
+    type: UPDATE_NETWORK_CONNECTION_STATE as typeof UPDATE_NETWORK_CONNECTION_STATE,
+    payload: isConnected,
+});
 
-export interface UpdateTracksAction extends PayloadAction<Record<string, Track> | null> {
-    type: Types.UPDATE_TRACKS;
-}
+export const updateParty = (party: Party) => ({
+    type: UPDATE_PARTY as typeof UPDATE_PARTY,
+    payload: party,
+});
 
-export interface UpdateUserVotesAction extends PayloadAction<Record<string, boolean> | null> {
-    type: Types.UPDATE_USER_VOTES;
-}
+export const updateTracks = (tracks: Record<string, Track> | null) => ({
+    type: UPDATE_TRACKS as typeof UPDATE_TRACKS,
+    payload: tracks,
+});
 
-export interface UpdatePlaybackStateAction extends PayloadAction<Partial<Playback>> {
-    type: Types.UPDATE_PLAYBACK_STATE;
-}
+export const updateUserVotes = (votes: Record<string, boolean> | null) => ({
+    type: UPDATE_USER_VOTES as typeof UPDATE_USER_VOTES,
+    payload: votes,
+});
 
-export function becomePlaybackMaster(): BecomePlaybackMasterAction {
-    return { type: Types.BECOME_PLAYBACK_MASTER };
-}
+export const updatePlaybackState = (playback: Partial<Playback>) => ({
+    type: UPDATE_PLAYBACK_STATE as typeof UPDATE_PLAYBACK_STATE,
+    payload: playback,
+});
 
-export function cleanupParty(): CleanupPartyAction {
-    return { type: Types.CLEANUP_PARTY };
-}
-
-export function createPartyFail(err: Error): CreatePartyFailAction {
-    return {
-        type: Types.CREATE_PARTY_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function createPartyStart(): CreatePartyStartAction {
-    return { type: Types.CREATE_PARTY_Start };
-}
+/* Utils */
 
 export async function createNewParty(
     displayName: string,
@@ -145,48 +141,6 @@ export async function createNewParty(
     return result.key;
 }
 
-export function joinPartyFail(err: Error): JoinPartyFailAction {
-    return {
-        type: Types.JOIN_PARTY_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function joinPartyStart(): JoinPartyStartAction {
-    return { type: Types.JOIN_PARTY_Start };
-}
-
-export function installPlaybackMaster(): InstallPlaybackMasterAction {
-    return { type: Types.INSTALL_PLAYBACK_MASTER };
-}
-
-export function openPartyFail(err: Error): OpenPartyFailAction {
-    return {
-        type: Types.OPEN_PARTY_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function openPartyFinish(party: Party): OpenPartyFinishAction {
-    return {
-        type: Types.OPEN_PARTY_Finish,
-        payload: party,
-    };
-}
-
-export function openPartyStart(id: string): OpenPartyStartAction {
-    return {
-        type: Types.OPEN_PARTY_Start,
-        payload: id,
-    };
-}
-
-export function resignPlaybackMaster(): ResignPlaybackMasterAction {
-    return { type: Types.RESIGN_PLAYBACK_MASTER };
-}
-
 export async function resolveShortId(shortId: string): Promise<string | null> {
     const snapshot = await firebase.database!()
         .ref('/parties')
@@ -205,36 +159,4 @@ export async function resolveShortId(shortId: string): Promise<string | null> {
     );
 
     return possibleLongId || null; // Filter out empty IDs
-}
-
-export function updateConnectionState(isConnected: ConnectionState): UpdateNetworkConnectionStateAction {
-    return {
-        type: Types.UPDATE_NETWORK_CONNECTION_STATE,
-        payload: isConnected,
-    };
-}
-
-export function updateParty(party: Party): UpdatePartyAction {
-    return {
-        type: Types.UPDATE_PARTY,
-        payload: party,
-    };
-}
-
-export function updateTracks(tracks: Record<string, Track> | null): UpdateTracksAction {
-    return {
-        type: Types.UPDATE_TRACKS,
-        payload: tracks,
-    };
-}
-
-export function updateUserVotes(votes: Record<string, boolean> | null): UpdateUserVotesAction {
-    return {
-        type: Types.UPDATE_USER_VOTES,
-        payload: votes,
-    };
-}
-
-export function updatePlaybackState(payload: Partial<Playback>): UpdatePlaybackStateAction {
-    return { type: Types.UPDATE_PLAYBACK_STATE, payload };
 }

--- a/src/actions/playback-spotify.ts
+++ b/src/actions/playback-spotify.ts
@@ -1,103 +1,55 @@
-import { ErrorAction, PayloadAction, Types } from '.';
-
 export type Actions =
-    | PlayerInitStartAction
-    | PlayerInitFinishAction
-    | PlayerErrorAction
-    | SpotifySdkInitFinishAction
-    | PlayAction
-    | PauseAction
-    | TogglePlaybackStartAction
-    | TogglePlaybackFinishAction
-    | TogglePlaybackFailAction
-    | SetPlayerCompatibilityAction;
+    | ReturnType<typeof playerInitFinish>
+    | ReturnType<typeof playerError>
+    | ReturnType<typeof spotifySdkInitFinish>
+    | ReturnType<typeof play>
+    | ReturnType<typeof pause>
+    | ReturnType<typeof togglePlaybackFail>
+    | ReturnType<typeof togglePlaybackFinish>
+    | ReturnType<typeof togglePlaybackStart>
+    | ReturnType<typeof setPlayerCompatibility>;
 
-export interface PlayerErrorAction extends ErrorAction {
-    type: Types.PLAYER_ERROR;
-}
+export const PLAYER_INIT_FINISH = 'PLAYER_INIT_Finish';
+export const PLAYER_ERROR = 'PLAYER_ERROR';
+export const PLAY = 'PLAY';
+export const PAUSE = 'PAUSE';
+export const SPOTIFY_SDK_INIT_FINISH = 'SPOTIFY_SDK_INIT_Finish';
+export const TOGGLE_PLAYBACK_FAIL = 'TOGGLE_PLAYBACK_Fail';
+export const TOGGLE_PLAYBACK_FINISH = 'TOGGLE_PLAYBACK_Finish';
+export const TOGGLE_PLAYBACK_START = 'TOGGLE_PLAYBACK_Start';
+export const SET_PLAYER_COMPATIBILITY = 'SET_PLAYER_COMPATIBILITY';
 
-export interface PlayerInitStartAction {
-    type: Types.PLAYER_INIT_Start;
-}
+export const playerInitFinish = (deviceId: string) => ({
+    type: PLAYER_INIT_FINISH as typeof PLAYER_INIT_FINISH,
+    payload: deviceId,
+});
 
-export interface PlayerInitFinishAction extends PayloadAction<string> {
-    type: Types.PLAYER_INIT_Finish;
-}
+export const playerError = (error: Error) => ({
+    type: PLAYER_ERROR as typeof PLAYER_ERROR,
+    error: true,
+    payload: error,
+});
 
-export interface TogglePlaybackStartAction {
-    type: Types.TOGGLE_PLAYBACK_Start;
-}
+export const play = (trackId: string, position: number) => ({
+    type: PLAY as typeof PLAY,
+    payload: { trackId, position },
+});
 
-export interface TogglePlaybackFinishAction {
-    type: Types.TOGGLE_PLAYBACK_Finish;
-}
+export const pause = () => ({ type: PAUSE as typeof PAUSE });
 
-export interface TogglePlaybackFailAction extends ErrorAction {
-    type: Types.TOGGLE_PLAYBACK_Fail;
-}
+export const spotifySdkInitFinish = () => ({ type: SPOTIFY_SDK_INIT_FINISH as typeof SPOTIFY_SDK_INIT_FINISH });
 
-export interface SpotifySdkInitFinishAction {
-    type: Types.SPOTIFY_SDK_INIT_Finish;
-}
+export const togglePlaybackStart = () => ({ type: TOGGLE_PLAYBACK_START as typeof TOGGLE_PLAYBACK_START });
 
-export interface PlayAction extends PayloadAction<{trackId: string, position: number}> {
-    type: Types.PLAY;
-}
+export const togglePlaybackFinish = () => ({ type: TOGGLE_PLAYBACK_FINISH as typeof TOGGLE_PLAYBACK_FINISH });
 
-export interface PauseAction {
-    type: Types.PAUSE;
-}
+export const togglePlaybackFail = (err: Error) => ({
+    type: TOGGLE_PLAYBACK_FAIL as typeof TOGGLE_PLAYBACK_FAIL,
+    error: true,
+    payload: err,
+});
 
-export interface SetPlayerCompatibilityAction extends PayloadAction<boolean> {
-    type: Types.SET_PLAYER_COMPATIBILITY;
-}
-
-export function playerInitFinish(deviceId: string): PlayerInitFinishAction {
-    return {
-        type: Types.PLAYER_INIT_Finish,
-        payload: deviceId,
-    };
-}
-
-export function playerError(error: Error): PlayerErrorAction {
-    return {
-        type: Types.PLAYER_ERROR,
-        error: true,
-        payload: error,
-    };
-}
-
-export function play(trackId: string, position: number): PlayAction {
-    return { type: Types.PLAY, payload: {trackId, position} };
-}
-
-export function pause(): PauseAction {
-    return { type: Types.PAUSE };
-}
-
-export function spotifySdkInitFinish(): SpotifySdkInitFinishAction {
-    return { type: Types.SPOTIFY_SDK_INIT_Finish };
-}
-
-export function togglePlaybackStart(): TogglePlaybackStartAction {
-    return { type: Types.TOGGLE_PLAYBACK_Start };
-}
-
-export function togglePlaybackFinish(): TogglePlaybackFinishAction {
-    return { type: Types.TOGGLE_PLAYBACK_Finish };
-}
-
-export function togglePlaybackFail(err: Error): TogglePlaybackFailAction {
-    return {
-        type: Types.TOGGLE_PLAYBACK_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function setPlayerCompatibility(compatible: boolean): SetPlayerCompatibilityAction {
-    return {
-        type: Types.SET_PLAYER_COMPATIBILITY,
-        payload: compatible,
-    };
-}
+export const setPlayerCompatibility = (compatible: boolean) => ({
+    type: SET_PLAYER_COMPATIBILITY as typeof SET_PLAYER_COMPATIBILITY,
+    payload: compatible,
+});

--- a/src/actions/queue.ts
+++ b/src/actions/queue.ts
@@ -6,24 +6,31 @@ import { Track, TrackReference } from '../state';
 import { requireAuth } from '../util/auth';
 import firebase, { firebaseNS } from '../util/firebase';
 
-import { PayloadAction, Types } from '.';
-
 export type Actions =
-    | RemoveTrackAction
-    | RequestSetVoteAction
-    | SetVoteAction;
+    | ReturnType<typeof removeTrackAction>
+    | ReturnType<typeof requestSetVoteAction>
+    | ReturnType<typeof setVoteAction>;
 
-export interface RemoveTrackAction extends PayloadAction<[TrackReference, boolean]> {
-    type: Types.REMOVE_TRACK;
-}
+export const REMOVE_TRACK = 'REMOVE_TRACK';
+export const REQUEST_SET_VOTE = 'REQUEST_SET_VOTE';
+export const SET_VOTE = 'SET_VOTE';
 
-export interface RequestSetVoteAction extends PayloadAction<[TrackReference, boolean]> {
-    type: Types.REQUEST_SET_VOTE;
-}
+export const removeTrackAction = (ref: TrackReference, moveToHistory: boolean) => ({
+    type: REMOVE_TRACK as typeof REMOVE_TRACK,
+    payload: [ref, moveToHistory] as [TrackReference, boolean],
+});
 
-export interface SetVoteAction extends PayloadAction<[TrackReference, boolean]> {
-    type: Types.SET_VOTE;
-}
+export const requestSetVoteAction = (ref: TrackReference, vote: boolean) => ({
+    type: REQUEST_SET_VOTE as typeof REQUEST_SET_VOTE,
+    payload: [ref, vote],
+});
+
+export const setVoteAction = (ref: TrackReference, vote: boolean) => ({
+    type: SET_VOTE as typeof SET_VOTE,
+    payload: [ref, vote] as [TrackReference, boolean],
+});
+
+/* Utils */
 
 export function markTrackAsPlayed(partyId: string, ref: TrackReference): Promise<void> {
     return firebase.database!()
@@ -83,20 +90,6 @@ export async function removeTrack(
     await Promise.all(updates);
 }
 
-export function removeTrackAction(ref: TrackReference, moveToHistory: boolean): RemoveTrackAction {
-    return {
-        type: Types.REMOVE_TRACK,
-        payload: [ref, moveToHistory],
-    };
-}
-
-export function requestSetVoteAction(ref: TrackReference, vote: boolean): RequestSetVoteAction {
-    return {
-        type: Types.REQUEST_SET_VOTE,
-        payload: [ref, vote],
-    };
-}
-
 export async function setVote(
     partyId: string,
     ref: TrackReference,
@@ -119,11 +112,4 @@ export async function setVote(
         .set(vote);
 
     await Promise.all([a, b]);
-}
-
-export function setVoteAction(ref: TrackReference, vote: boolean): SetVoteAction {
-    return {
-        type: Types.SET_VOTE,
-        payload: [ref, vote],
-    };
 }

--- a/src/actions/view-home.ts
+++ b/src/actions/view-home.ts
@@ -1,15 +1,9 @@
-import { PayloadAction, Types } from '.';
-
 export type Actions =
-    | ChangePartyIdAction;
+    | ReturnType<typeof changePartyId>;
 
-export interface ChangePartyIdAction extends PayloadAction<string> {
-    type: Types.CHANGE_PARTY_ID;
-}
+export const CHANGE_PARTY_ID = 'CHANGE_PARTY_ID';
 
-export function changePartyId(partyId: string): ChangePartyIdAction {
-    return {
-        type: Types.CHANGE_PARTY_ID,
-        payload: partyId,
-    };
-}
+export const changePartyId = (partyId: string) => ({
+    type: CHANGE_PARTY_ID as typeof CHANGE_PARTY_ID,
+    payload: partyId,
+});

--- a/src/actions/view-party-settings.ts
+++ b/src/actions/view-party-settings.ts
@@ -6,99 +6,97 @@ import { PartySettings, Playlist, PlaylistReference, Track } from '../state';
 import firebase from '../util/firebase';
 import { fetchWithAccessToken } from '../util/spotify-auth';
 
-import { ErrorAction, PayloadAction, Types } from '.';
-
 export type Actions =
-    | ChangeFallbackPlaylistSearchInputAction
-    | ChangePartySettingAction<keyof PartySettings>
-    | FlushQueueFailAction
-    | FlushQueueFinishAction
-    | FlushQueueStartAction
-    | InsertFallbackPlaylistFailAction
-    | InsertFallbackPlaylistFinishAction
-    | InsertFallbackPlaylistProgressAction
-    | InsertFallbackPlaylistStartAction
-    | LoadPlaylistsStartAction
-    | LoadPlaylistsFailAction
-    | UpdatePartyNameAction
-    | UpdateUserPlaylistsAction;
+    | ReturnType<typeof changeSearchInput>
+    | ReturnType<typeof changePartyName>
+    | ReturnType<typeof changePartySetting>
+    | ReturnType<typeof flushQueueStart>
+    | ReturnType<typeof flushQueueFail>
+    | ReturnType<typeof flushQueueFinish>
+    | ReturnType<typeof insertPlaylistFail>
+    | ReturnType<typeof insertPlaylistFinish>
+    | ReturnType<typeof insertPlaylistProgress>
+    | ReturnType<typeof insertPlaylistStart>
+    | ReturnType<typeof loadPlaylistsFail>
+    | ReturnType<typeof loadPlaylistsStart>
+    | ReturnType<typeof updateUserPlaylists>;
 
-export interface ChangeFallbackPlaylistSearchInputAction extends PayloadAction<string> {
-    type: Types.CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT;
-}
+export const UPDATE_PARTY_NAME = 'CHANGE_PARTYNAME';
+export const CHANGE_PARTY_SETTING = 'CHANGE_PARTY_SETTING';
+export const CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT = 'CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT';
+export const FLUSH_QUEUE_FAIL = 'FLUSH_QUEUE_Fail';
+export const FLUSH_QUEUE_FINISH = 'FLUSH_QUEUE_Finish';
+export const FLUSH_QUEUE_START = 'FLUSH_QUEUE_Start';
+export const LOAD_PLAYLISTS_FAIL = 'LOAD_PLAYLISTS_Fail';
+export const LOAD_PLAYLISTS_START = 'LOAD_PLAYLISTS_Start';
+export const INSERT_FALLBACK_PLAYLIST_FAIL = 'INSERT_FALLBACK_PLAYLIST_Fail';
+export const INSERT_FALLBACK_PLAYLIST_FINISH = 'INSERT_FALLBACK_PLAYLIST_Finish';
+export const INSERT_FALLBACK_PLAYLIST_PROGRESS = 'INSERT_FALLBACK_PLAYLIST_Progress';
+export const INSERT_FALLBACK_PLAYLIST_START = 'INSERT_FALLBACK_PLAYLIST_Start';
+export const UPDATE_USER_PLAYLISTS = 'UPDATE_USER_PLAYLISTS';
 
-export interface ChangePartySettingAction<K extends keyof PartySettings> extends
-    PayloadAction<{ setting: K, value: PartySettings[K] }> {
-    type: Types.CHANGE_PARTY_SETTING;
-}
+export const changePartyName = (newName: string) => ({
+    type: UPDATE_PARTY_NAME as typeof UPDATE_PARTY_NAME,
+    payload: newName,
+});
 
-export interface FlushQueueFailAction extends ErrorAction {
-    type: Types.FLUSH_QUEUE_Fail;
-}
-
-export interface FlushQueueFinishAction {
-    type: Types.FLUSH_QUEUE_Finish;
-}
-
-export interface FlushQueueStartAction {
-    type: Types.FLUSH_QUEUE_Start;
-}
-
-export interface InsertFallbackPlaylistFailAction extends ErrorAction {
-    type: Types.INSERT_FALLBACK_PLAYLIST_Fail;
-}
-
-export interface InsertFallbackPlaylistFinishAction {
-    type: Types.INSERT_FALLBACK_PLAYLIST_Finish;
-}
-
-export interface InsertFallbackPlaylistProgressAction extends PayloadAction<number> {
-    type: Types.INSERT_FALLBACK_PLAYLIST_Progress;
-}
-
-export interface InsertFallbackPlaylistStartAction extends PayloadAction<{ playlist: Playlist, shuffled: boolean }> {
-    type: Types.INSERT_FALLBACK_PLAYLIST_Start;
-}
-
-export interface LoadPlaylistsStartAction {
-    type: Types.LOAD_PLAYLISTS_Start;
-}
-
-export interface LoadPlaylistsFailAction extends ErrorAction {
-    type: Types.LOAD_PLAYLISTS_Fail;
-}
-
-export interface UpdatePartyNameAction extends PayloadAction<string> {
-    type: Types.UPDATE_PARTY_NAME;
-}
-
-export interface UpdateUserPlaylistsAction extends PayloadAction<Playlist[]> {
-    type: Types.UPDATE_USER_PLAYLISTS;
-}
-
-export function changePartySetting<K extends keyof PartySettings>(
+export const changePartySetting = <K extends keyof PartySettings>(
     setting: K,
     value: PartySettings[K],
-): ChangePartySettingAction<K> {
-    return {
-        type: Types.CHANGE_PARTY_SETTING,
-        payload: { value, setting },
-    };
-}
+) => ({
+    type: CHANGE_PARTY_SETTING as typeof CHANGE_PARTY_SETTING,
+    payload: { value, setting },
+});
 
-export function changePartyName(newName: string): UpdatePartyNameAction {
-    return {
-        type: Types.UPDATE_PARTY_NAME,
-        payload: newName,
-    };
-}
+export const changeSearchInput = (newContent: string) => ({
+    type: CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT as typeof CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT,
+    payload: newContent,
+});
 
-export function changeSearchInput(newContent: string): ChangeFallbackPlaylistSearchInputAction {
-    return {
-        type: Types.CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT,
-        payload: newContent,
-    };
-}
+export const flushQueueFail = (err: Error) => ({
+    type: FLUSH_QUEUE_FAIL as typeof FLUSH_QUEUE_FAIL,
+    error: true,
+    payload: err,
+});
+
+export const flushQueueFinish = () => ({ type: FLUSH_QUEUE_FINISH as typeof FLUSH_QUEUE_FINISH });
+
+export const flushQueueStart = () => ({ type: FLUSH_QUEUE_START as typeof FLUSH_QUEUE_START });
+
+export const loadPlaylistsFail = (err: Error) => ({
+    type: LOAD_PLAYLISTS_FAIL as typeof LOAD_PLAYLISTS_FAIL,
+    error: true,
+    payload: err,
+});
+
+export const loadPlaylistsStart = () => ({ type: LOAD_PLAYLISTS_START as typeof LOAD_PLAYLISTS_START });
+
+export const insertPlaylistFail = (err: Error) => ({
+    type: INSERT_FALLBACK_PLAYLIST_FAIL as typeof INSERT_FALLBACK_PLAYLIST_FAIL,
+    error: true,
+    payload: err,
+});
+
+export const insertPlaylistFinish = () => ({
+    type: INSERT_FALLBACK_PLAYLIST_FINISH as typeof INSERT_FALLBACK_PLAYLIST_FINISH,
+});
+
+export const insertPlaylistProgress = (itemsProcessed: number) => ({
+    type: INSERT_FALLBACK_PLAYLIST_PROGRESS as typeof INSERT_FALLBACK_PLAYLIST_PROGRESS,
+    payload: itemsProcessed,
+});
+
+export const insertPlaylistStart = (playlist: Playlist, shuffled: boolean) => ({
+    type: INSERT_FALLBACK_PLAYLIST_START as typeof INSERT_FALLBACK_PLAYLIST_START,
+    payload: { playlist, shuffled },
+});
+
+export const updateUserPlaylists = (playlists: Playlist[]) => ({
+    type: UPDATE_USER_PLAYLISTS as typeof UPDATE_USER_PLAYLISTS,
+    payload: playlists,
+});
+
+/* Utils */
 
 export async function flushQueue(partyId: string, tracks: Track[]) {
     const trackRemoveObject = {};
@@ -121,22 +119,6 @@ export async function flushQueue(partyId: string, tracks: Track[]) {
     ]);
 }
 
-export function flushQueueFail(err: Error): FlushQueueFailAction {
-    return {
-        type: Types.FLUSH_QUEUE_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function flushQueueFinish(): FlushQueueFinishAction {
-    return { type: Types.FLUSH_QUEUE_Finish };
-}
-
-export function flushQueueStart(): FlushQueueStartAction {
-    return { type: Types.FLUSH_QUEUE_Start };
-}
-
 export async function loadPlaylists(): Promise<Playlist[]> {
     const items: SpotifyApi.PlaylistObjectSimplified[] = [];
     let url = '/me/playlists?limit=50';
@@ -157,18 +139,6 @@ export async function loadPlaylists(): Promise<Playlist[]> {
         } as PlaylistReference,
         trackCount: tracks.total,
     }));
-}
-
-export function loadPlaylistsFail(err: Error): LoadPlaylistsFailAction {
-    return {
-        type: Types.LOAD_PLAYLISTS_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function loadPlaylistsStart(): LoadPlaylistsStartAction {
-    return { type: Types.LOAD_PLAYLISTS_Start };
 }
 
 export async function insertPlaylist(
@@ -260,37 +230,4 @@ export async function insertPlaylist(
         .ref('/tracks')
         .child(partyId)
         .update(updateObject);
-}
-
-export function insertPlaylistFail(err: Error): InsertFallbackPlaylistFailAction {
-    return {
-        type: Types.INSERT_FALLBACK_PLAYLIST_Fail,
-        error: true,
-        payload: err,
-    };
-}
-
-export function insertPlaylistFinish(): InsertFallbackPlaylistFinishAction {
-    return { type: Types.INSERT_FALLBACK_PLAYLIST_Finish };
-}
-
-export function insertPlaylistProgress(itemsProcessed: number): InsertFallbackPlaylistProgressAction {
-    return {
-        type: Types.INSERT_FALLBACK_PLAYLIST_Progress,
-        payload: itemsProcessed,
-    };
-}
-
-export function insertPlaylistStart(playlist: Playlist, shuffled: boolean): InsertFallbackPlaylistStartAction {
-    return {
-        type: Types.INSERT_FALLBACK_PLAYLIST_Start,
-        payload: { playlist, shuffled },
-    };
-}
-
-export function updateUserPlaylists(playlists: Playlist[]): UpdateUserPlaylistsAction {
-    return {
-        type: Types.UPDATE_USER_PLAYLISTS,
-        payload: playlists,
-    };
 }

--- a/src/actions/view-party-share.ts
+++ b/src/actions/view-party-share.ts
@@ -1,12 +1,6 @@
-import { Types } from '.';
-
 export type Actions =
-    | SharePartyAction;
+    | ReturnType<typeof shareParty>;
 
-export interface SharePartyAction {
-    type: Types.SHARE_PARTY;
-}
+export const SHARE_PARTY = 'SHARE_PARTY';
 
-export function shareParty(): SharePartyAction {
-    return { type: Types.SHARE_PARTY };
-}
+export const shareParty = () => ({ type: SHARE_PARTY as typeof SHARE_PARTY });

--- a/src/actions/view-party.ts
+++ b/src/actions/view-party.ts
@@ -1,67 +1,39 @@
 import { Track } from '../state';
 
-import { ErrorAction, PayloadAction, Types } from '.';
-
 export type Actions =
-    | ChangeDisplayLoginModalAction
-    | ChangeTrackSearchInputAction
-    | SearchStartAction
-    | SearchFinishAction
-    | SearchFailAction;
+    | ReturnType<typeof changeDisplayLoginModal>
+    | ReturnType<typeof changeTrackSearchInput>
+    | ReturnType<typeof searchFail>
+    | ReturnType<typeof searchFinish>
+    | ReturnType<typeof searchStart>;
 
-export interface ChangeDisplayLoginModalAction extends PayloadAction<boolean> {
-    type: Types.CHANGE_DISPLAY_LOGIN_MODAL;
-}
+export const CHANGE_DISPLAY_LOGIN_MODAL = 'CHANGE_DISPLAY_LOGIN_MODAL';
+export const CHANGE_TRACK_SEARCH_INPUT = 'CHANGE_TRACK_SEARCH_INPUT';
+export const SEARCH_FAIL = 'SEARCH_Fail';
+export const SEARCH_FINISH = 'SEARCH_Finish';
+export const SEARCH_START = 'SEARCH_Start';
 
-export interface ChangeTrackSearchInputAction extends PayloadAction<string> {
-    type: Types.CHANGE_TRACK_SEARCH_INPUT;
-}
+export const changeDisplayLoginModal = (display: boolean) => ({
+    type: CHANGE_DISPLAY_LOGIN_MODAL as typeof CHANGE_DISPLAY_LOGIN_MODAL,
+    payload: display,
+});
 
-export interface SearchStartAction {
-    type: Types.SEARCH_Start;
-}
+export const changeTrackSearchInput = (text: string) => ({
+    type: CHANGE_TRACK_SEARCH_INPUT as typeof CHANGE_TRACK_SEARCH_INPUT,
+    payload: text,
+});
 
-export interface SearchFinishAction extends PayloadAction<Record<string, Track>> {
-    type: Types.SEARCH_Finish;
-}
+export const eraseTrackSearchInput = () => changeTrackSearchInput('');
 
-export interface SearchFailAction extends ErrorAction {
-    type: Types.SEARCH_Fail;
-}
+export const searchFail = (error: Error) => ({
+    type: SEARCH_FAIL as typeof SEARCH_FAIL,
+    error: true,
+    payload: error,
+});
 
-export function changeDisplayLoginModal(display: boolean): ChangeDisplayLoginModalAction {
-    return {
-        type: Types.CHANGE_DISPLAY_LOGIN_MODAL,
-        payload: display,
-    };
-}
+export const searchFinish = (tracks: Record<string, Track>) => ({
+    type: SEARCH_FINISH as typeof SEARCH_FINISH,
+    payload: tracks,
+});
 
-export function changeTrackSearchInput(text: string): ChangeTrackSearchInputAction {
-    return {
-        type: Types.CHANGE_TRACK_SEARCH_INPUT,
-        payload: text,
-    };
-}
-
-export function eraseTrackSearchInput(): ChangeTrackSearchInputAction {
-    return changeTrackSearchInput('');
-}
-
-export function searchFail(error: Error): SearchFailAction {
-    return {
-        type: Types.SEARCH_Fail,
-        error: true,
-        payload: error,
-    };
-}
-
-export function searchFinish(tracks: Record<string, Track>): SearchFinishAction {
-    return {
-        type: Types.SEARCH_Finish,
-        payload: tracks,
-    };
-}
-
-export function searchStart(): SearchStartAction {
-    return { type: Types.SEARCH_Start };
-}
+export const searchStart = () => ({ type: SEARCH_START as typeof SEARCH_START });

--- a/src/actions/view-queue-drawer.ts
+++ b/src/actions/view-queue-drawer.ts
@@ -1,12 +1,6 @@
-import { Types } from '.';
-
 export type Actions =
-    | ToggleUserMenuAction;
+    | ReturnType<typeof toggleUserMenu>;
 
-export interface ToggleUserMenuAction {
-    type: Types.TOGGLE_USER_MENU;
-}
+export const TOGGLE_USER_MENU = 'TOGGLE_USER_MENU';
 
-export function toggleUserMenu(): ToggleUserMenuAction {
-    return { type: Types.TOGGLE_USER_MENU };
-}
+export const toggleUserMenu = () => ({ type: TOGGLE_USER_MENU as typeof TOGGLE_USER_MENU });

--- a/src/reducers/app-shell.ts
+++ b/src/reducers/app-shell.ts
@@ -1,4 +1,4 @@
-import { Actions, Types } from '../actions';
+import { Actions, HIDE_TOAST, SHOW_TOAST } from '../actions';
 import { AppShellState } from '../state';
 
 export default function(
@@ -6,12 +6,12 @@ export default function(
     action: Actions,
 ): AppShellState {
     switch (action.type) {
-        case Types.HIDE_TOAST:
+        case HIDE_TOAST:
             return {
                 ...state,
                 currentToast: null,
             };
-        case Types.SHOW_TOAST:
+        case SHOW_TOAST:
             return {
                 ...state,
                 currentToast: action.payload.text,

--- a/src/reducers/metadata.ts
+++ b/src/reducers/metadata.ts
@@ -1,6 +1,7 @@
 import merge from 'lodash-es/merge';
 
-import { Actions, Types } from '../actions';
+import { Actions } from '../actions';
+import { UPDATE_METADATA } from '../actions/metadata';
 import { Metadata } from '../state';
 
 export default function(
@@ -8,7 +9,7 @@ export default function(
     action: Actions,
 ): Record<string, Metadata> {
     switch (action.type) {
-        case Types.UPDATE_METADATA:
+        case UPDATE_METADATA:
             return merge({}, state, action.payload);
         default:
             return state;

--- a/src/reducers/party.ts
+++ b/src/reducers/party.ts
@@ -1,4 +1,16 @@
-import { Actions, Types } from '../actions';
+import { Actions } from '../actions';
+import {
+    CLEANUP_PARTY,
+    OPEN_PARTY_FAIL,
+    OPEN_PARTY_FINISH,
+    OPEN_PARTY_START,
+    UPDATE_NETWORK_CONNECTION_STATE,
+    UPDATE_PARTY,
+    UPDATE_PLAYBACK_STATE,
+    UPDATE_TRACKS,
+    UPDATE_USER_VOTES,
+} from '../actions/party-data';
+import { SET_VOTE } from '../actions/queue';
 import { firebaseTrackIdSelector } from '../selectors/track';
 import { ConnectionState, PartyState, Track } from '../state';
 
@@ -17,25 +29,25 @@ export default function (
     action: Actions,
 ): PartyState {
     switch (action.type) {
-        case Types.OPEN_PARTY_Start:
+        case OPEN_PARTY_START:
             return {
                 ...state,
                 partyLoadError: null,
                 partyLoadInProgress: true,
             };
-        case Types.OPEN_PARTY_Fail:
+        case OPEN_PARTY_FAIL:
             return {
                 ...state,
                 partyLoadError: action.payload,
                 partyLoadInProgress: false,
             };
-        case Types.OPEN_PARTY_Finish:
+        case OPEN_PARTY_FINISH:
             return {
                 ...state,
                 partyLoadError: null,
                 partyLoadInProgress: false,
             };
-        case Types.SET_VOTE:
+        case SET_VOTE:
             const [ref, vote] = action.payload;
             const trackId = firebaseTrackIdSelector(ref);
 
@@ -60,28 +72,28 @@ export default function (
                     [trackId]: vote,
                 },
             };
-        case Types.UPDATE_NETWORK_CONNECTION_STATE:
+        case UPDATE_NETWORK_CONNECTION_STATE:
             return {
                 ...state,
                 connectionState: action.payload,
             };
-        case Types.UPDATE_PARTY:
+        case UPDATE_PARTY:
             return {
                 ...state,
                 currentParty: action.payload,
             };
-        case Types.UPDATE_TRACKS:
+        case UPDATE_TRACKS:
             return {
                 ...state,
                 hasTracksLoaded: true,
                 tracks: action.payload,
             };
-        case Types.UPDATE_USER_VOTES:
+        case UPDATE_USER_VOTES:
             return {
                 ...state,
                 userVotes: action.payload,
             };
-        case Types.UPDATE_PLAYBACK_STATE:
+        case UPDATE_PLAYBACK_STATE:
             if (!state.currentParty) {
                 return state;
             }
@@ -96,7 +108,7 @@ export default function (
                     },
                 },
             };
-        case Types.CLEANUP_PARTY:
+        case CLEANUP_PARTY:
             return {
                 connectionState: ConnectionState.Unknown,
                 currentParty: null,

--- a/src/reducers/player.ts
+++ b/src/reducers/player.ts
@@ -1,4 +1,13 @@
-import { Actions, Types } from '../actions';
+import { Actions, ASSIGN_INSTANCE_ID } from '../actions';
+import {
+    PLAYER_ERROR,
+    PLAYER_INIT_FINISH,
+    SET_PLAYER_COMPATIBILITY,
+    SPOTIFY_SDK_INIT_FINISH,
+    TOGGLE_PLAYBACK_FAIL,
+    TOGGLE_PLAYBACK_FINISH,
+    TOGGLE_PLAYBACK_START,
+} from '../actions/playback-spotify';
 import { PlayerState } from '../state';
 
 export default function (
@@ -15,54 +24,48 @@ export default function (
     action: Actions,
 ): PlayerState {
     switch (action.type) {
-        case Types.ASSIGN_INSTANCE_ID:
+        case ASSIGN_INSTANCE_ID:
             return {
                 ...state,
                 instanceId: action.payload,
             };
-        case Types.PLAYER_INIT_Start:
-            return {
-                ...state,
-                initializing: true,
-                initializationError: null,
-            };
-        case Types.PLAYER_INIT_Finish:
+        case PLAYER_INIT_FINISH:
             return {
                 ...state,
                 initializing: false,
                 initializationError: null,
                 localDeviceId: action.payload,
             };
-        case Types.PLAYER_ERROR:
+        case PLAYER_ERROR:
             return {
                 ...state,
                 initializing: false,
                 initializationError: action.payload,
             };
-        case Types.TOGGLE_PLAYBACK_Start:
+        case TOGGLE_PLAYBACK_START:
             return {
                 ...state,
                 togglingPlayback: true,
                 togglePlaybackError: null,
             };
-        case Types.TOGGLE_PLAYBACK_Finish:
+        case TOGGLE_PLAYBACK_FINISH:
             return {
                 ...state,
                 togglingPlayback: false,
                 togglePlaybackError: null,
             };
-        case Types.TOGGLE_PLAYBACK_Fail:
+        case TOGGLE_PLAYBACK_FAIL:
             return {
                 ...state,
                 togglingPlayback: false,
                 togglePlaybackError: action.payload,
             };
-        case Types.SPOTIFY_SDK_INIT_Finish:
+        case SPOTIFY_SDK_INIT_FINISH:
             return {
                 ...state,
                 sdkReady: true,
             };
-        case Types.SET_PLAYER_COMPATIBILITY:
+        case SET_PLAYER_COMPATIBILITY:
             return {
                 ...state,
                 isCompatible: action.payload,

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -1,4 +1,12 @@
-import { Actions, Types } from '../actions';
+import { Actions } from '../actions';
+import {
+    EXCHANGE_CODE,
+    EXCHANGE_CODE_FAIL,
+    NOTIFY_AUTH_STATUS_KNOWN,
+    REQUIRE_FOLLOW_UP_LOGIN,
+} from '../actions/auth';
+import { CHANGE_DISPLAY_LOGIN_MODAL } from '../actions/view-party';
+import { UPDATE_USER_PLAYLISTS } from '../actions/view-party-settings';
 import { AuthProviderStatus, UserCredentials, UserState } from '../state';
 
 const defaultUser = <T>(): AuthProviderStatus<T> => ({
@@ -40,7 +48,7 @@ export default function(
     }
 
     switch (action.type) {
-        case Types.CHANGE_DISPLAY_LOGIN_MODAL:
+        case CHANGE_DISPLAY_LOGIN_MODAL:
             if (state.needsFollowUpSignInWithProviders) {
                 return {
                     ...state,
@@ -49,31 +57,31 @@ export default function(
             } else {
                 return state;
             }
-        case Types.EXCHANGE_CODE_Fail:
+        case EXCHANGE_CODE_FAIL:
             return reduceAuthProvider(action.payload.provider, {
                 authorizing: false,
                 authorizationError: action.payload.data,
                 statusKnown: true,
             });
-        case Types.EXCHANGE_CODE_Start:
+        case EXCHANGE_CODE:
             return reduceAuthProvider(action.payload, {
                 authorizing: true,
                 authorizationError: null,
                 statusKnown: false,
             });
-        case Types.NOTIFY_AUTH_STATUS_KNOWN:
+        case NOTIFY_AUTH_STATUS_KNOWN:
             return reduceAuthProvider(action.payload.provider, {
                 authorizing: false,
                 authorizationError: null,
                 statusKnown: true,
                 user: action.payload.data,
             });
-        case Types.REQUIRE_FOLLOW_UP_LOGIN:
+        case REQUIRE_FOLLOW_UP_LOGIN:
             return {
                 ...state,
                 needsFollowUpSignInWithProviders: action.payload,
             };
-        case Types.UPDATE_USER_PLAYLISTS:
+        case UPDATE_USER_PLAYLISTS:
             return {
                 ...state,
                 playlists: action.payload,

--- a/src/reducers/view-home.ts
+++ b/src/reducers/view-home.ts
@@ -1,4 +1,12 @@
-import { Actions, Types } from '../actions';
+import { Actions } from '../actions';
+import {
+    CREATE_PARTY_FAIL,
+    CREATE_PARTY_START,
+    JOIN_PARTY_FAIL,
+    JOIN_PARTY_START,
+    OPEN_PARTY_START,
+} from '../actions/party-data';
+import { CHANGE_PARTY_ID } from '../actions/view-home';
 import { HomeViewState } from '../state';
 
 export default function(
@@ -13,37 +21,37 @@ export default function(
     action: Actions,
 ): HomeViewState {
     switch (action.type) {
-        case Types.CHANGE_PARTY_ID:
+        case CHANGE_PARTY_ID:
             return {
                 ...state,
                 partyId: action.payload,
                 partyIdValid: /[0-9]+/.test(action.payload),
             };
-        case Types.CREATE_PARTY_Start:
+        case CREATE_PARTY_START:
             return {
                 ...state,
                 partyCreationError: null,
                 partyCreationInProgress: true,
             };
-        case Types.CREATE_PARTY_Fail:
+        case CREATE_PARTY_FAIL:
             return {
                 ...state,
                 partyCreationError: action.payload,
                 partyCreationInProgress: false,
             };
-        case Types.JOIN_PARTY_Start:
+        case JOIN_PARTY_START:
             return {
                 ...state,
                 partyJoinError: null,
                 partyJoinInProgress: true,
             };
-        case Types.JOIN_PARTY_Fail:
+        case JOIN_PARTY_FAIL:
             return {
                 ...state,
                 partyJoinError: action.payload,
                 partyJoinInProgress: false,
             };
-        case Types.OPEN_PARTY_Start:
+        case OPEN_PARTY_START:
             if (!state.partyJoinInProgress && !state.partyCreationInProgress) {
                 return state;
             }

--- a/src/reducers/view-party.ts
+++ b/src/reducers/view-party.ts
@@ -1,7 +1,10 @@
 import { LOCATION_CHANGED } from '@festify/redux-little-router';
 
-import { Actions, Types } from '../actions';
-import { ChangeDisplayLoginModalAction, SearchFailAction, SearchFinishAction } from '../actions/view-party';
+import { Actions } from '../actions';
+import { REQUIRE_FOLLOW_UP_LOGIN } from '../actions/auth';
+import { CLEANUP_PARTY } from '../actions/party-data';
+import { CHANGE_DISPLAY_LOGIN_MODAL, SEARCH_FAIL, SEARCH_FINISH, SEARCH_START } from '../actions/view-party';
+import { TOGGLE_USER_MENU } from '../actions/view-queue-drawer';
 import { PartyViewState } from '../state';
 
 export default function(
@@ -15,10 +18,10 @@ export default function(
     action: Actions,
 ): PartyViewState {
     switch (action.type) {
-        case Types.CHANGE_DISPLAY_LOGIN_MODAL:
+        case CHANGE_DISPLAY_LOGIN_MODAL:
             return {
                 ...state,
-                loginModalOpen: (action as ChangeDisplayLoginModalAction).payload,
+                loginModalOpen: action.payload,
             };
         case LOCATION_CHANGED:
             return {
@@ -27,36 +30,36 @@ export default function(
                     ? null
                     : state.searchResult,
             };
-        case Types.REQUIRE_FOLLOW_UP_LOGIN:
+        case REQUIRE_FOLLOW_UP_LOGIN:
             return {
                 ...state,
                 loginModalOpen: true,
             };
-        case Types.SEARCH_Start:
+        case SEARCH_START:
             return {
                 ...state,
                 searchInProgress: true,
                 searchError: null,
             };
-        case Types.SEARCH_Fail:
+        case SEARCH_FAIL:
             return {
                 ...state,
                 searchInProgress: false,
-                searchError: (action as SearchFailAction).payload,
+                searchError: action.payload,
             };
-        case Types.SEARCH_Finish:
+        case SEARCH_FINISH:
             return {
                 ...state,
                 searchInProgress: false,
                 searchError: null,
-                searchResult: (action as SearchFinishAction).payload,
+                searchResult: action.payload,
             };
-        case Types.TOGGLE_USER_MENU:
+        case TOGGLE_USER_MENU:
             return {
                 ...state,
                 userMenuOpen: !state.userMenuOpen,
             };
-        case Types.CLEANUP_PARTY:
+        case CLEANUP_PARTY:
             return {
                 ...state,
                 searchInProgress: false,

--- a/src/reducers/view-settings.ts
+++ b/src/reducers/view-settings.ts
@@ -1,4 +1,17 @@
-import { Actions, Types } from '../actions';
+import { Actions } from '../actions';
+import {
+    CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT,
+    FLUSH_QUEUE_FAIL,
+    FLUSH_QUEUE_FINISH,
+    FLUSH_QUEUE_START,
+    INSERT_FALLBACK_PLAYLIST_FAIL,
+    INSERT_FALLBACK_PLAYLIST_FINISH,
+    INSERT_FALLBACK_PLAYLIST_PROGRESS,
+    INSERT_FALLBACK_PLAYLIST_START,
+    LOAD_PLAYLISTS_FAIL,
+    LOAD_PLAYLISTS_START,
+    UPDATE_USER_PLAYLISTS,
+} from '../actions/view-party-settings';
 import { SettingsViewState } from '../state';
 
 export default function(
@@ -16,30 +29,30 @@ export default function(
     action: Actions,
 ): SettingsViewState {
     switch (action.type) {
-        case Types.CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT:
+        case CHANGE_FALLBACK_PLAYLIST_SEARCH_INPUT:
             return {
                 ...state,
                 playlistSearchQuery: action.payload,
             };
-        case Types.FLUSH_QUEUE_Start:
+        case FLUSH_QUEUE_START:
             return {
                 ...state,
                 queueFlushError: null,
                 queueFlushInProgress: true,
             };
-        case Types.FLUSH_QUEUE_Fail:
+        case FLUSH_QUEUE_FAIL:
             return {
                 ...state,
                 queueFlushError: action.payload,
                 queueFlushInProgress: false,
             };
-        case Types.FLUSH_QUEUE_Finish:
+        case FLUSH_QUEUE_FINISH:
             return {
                 ...state,
                 queueFlushError: null,
                 queueFlushInProgress: false,
             };
-        case Types.INSERT_FALLBACK_PLAYLIST_Start:
+        case INSERT_FALLBACK_PLAYLIST_START:
             return {
                 ...state,
                 tracksLoadError: null,
@@ -47,14 +60,14 @@ export default function(
                 tracksToLoad: action.payload.playlist.trackCount,
                 tracksLoaded: 0,
             };
-        case Types.INSERT_FALLBACK_PLAYLIST_Progress:
+        case INSERT_FALLBACK_PLAYLIST_PROGRESS:
             return {
                 ...state,
                 tracksLoaded: state.tracksLoadInProgress
                     ? state.tracksLoaded + action.payload
                     : state.tracksLoaded,
             };
-        case Types.INSERT_FALLBACK_PLAYLIST_Fail:
+        case INSERT_FALLBACK_PLAYLIST_FAIL:
             return {
                 ...state,
                 tracksLoadError: action.payload,
@@ -62,7 +75,7 @@ export default function(
                 tracksToLoad: 0,
                 tracksLoaded: 0,
             };
-        case Types.INSERT_FALLBACK_PLAYLIST_Finish:
+        case INSERT_FALLBACK_PLAYLIST_FINISH:
             return {
                 ...state,
                 tracksLoadError: null,
@@ -70,19 +83,19 @@ export default function(
                 tracksToLoad: 0,
                 tracksLoaded: 0,
             };
-        case Types.LOAD_PLAYLISTS_Start:
+        case LOAD_PLAYLISTS_START:
             return {
                 ...state,
                 playlistLoadError: null,
                 playlistLoadInProgress: true,
             };
-        case Types.LOAD_PLAYLISTS_Fail:
+        case LOAD_PLAYLISTS_FAIL:
             return {
                 ...state,
                 playlistLoadError: action.payload,
                 playlistLoadInProgress: false,
             };
-        case Types.UPDATE_USER_PLAYLISTS:
+        case UPDATE_USER_PLAYLISTS:
             return {
                 ...state,
                 playlistLoadError: null,

--- a/src/sagas/auth.ts
+++ b/src/sagas/auth.ts
@@ -5,7 +5,7 @@ import { delay } from 'redux-saga';
 import { all, apply, call, fork, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 
 import { CLIENT_ID } from '../../spotify.config';
-import { showToast, Types } from '../actions';
+import { showToast } from '../actions';
 import {
     checkLoginStatus,
     exchangeCodeFail,
@@ -17,11 +17,14 @@ import {
     removeSavedFollowUpLoginCredentials,
     requireFollowUpLogin,
     saveFollowUpLoginCredentials,
+    triggerOAuthLogin as triggerOAuthLoginAction,
     welcomeUser,
-    TriggerOAuthLoginAction,
+    CHECK_LOGIN_STATUS,
+    LOGOUT,
+    TRIGGER_OAUTH_LOGIN,
 } from '../actions/auth';
 import { updatePlaybackState } from '../actions/party-data';
-import { ChangeDisplayLoginModalAction } from '../actions/view-party';
+import { changeDisplayLoginModal, CHANGE_DISPLAY_LOGIN_MODAL } from '../actions/view-party';
 import { isPlaybackMasterSelector } from '../selectors/party';
 import { getProvider, requireAuth, AuthData } from '../util/auth';
 import firebase, { functions } from '../util/firebase';
@@ -61,7 +64,7 @@ function* checkLogin() {
  *
  * @param ac the redux action
  */
-function* handleFollowUpCancellation(ac: ChangeDisplayLoginModalAction) {
+function* handleFollowUpCancellation(ac: ReturnType<typeof changeDisplayLoginModal>) {
     if (!ac.payload && hasFollowUpCredentials()) {
         yield call(removeSavedFollowUpLoginCredentials);
         yield call(AuthData.remove, LOCALSTORAGE_KEY);
@@ -247,7 +250,7 @@ function* refreshFirebaseAuth() {
     }
 }
 
-function* triggerOAuthLogin(ac: TriggerOAuthLoginAction) {
+function* triggerOAuthLogin(ac: ReturnType<typeof triggerOAuthLoginAction>) {
     if (ac.payload === 'spotify') {
         yield call(console.log, 'Only the swaggiest of developers hacking on Festify will see this 🙌.');
         localStorage[AUTH_REDIRECT_LOCAL_STORAGE_KEY] =
@@ -267,10 +270,10 @@ function* triggerOAuthLogin(ac: TriggerOAuthLoginAction) {
 
 export default function*() {
     yield fork(refreshFirebaseAuth);
-    yield takeEvery(Types.CHANGE_DISPLAY_LOGIN_MODAL, handleFollowUpCancellation);
-    yield takeEvery(Types.CHECK_LOGIN_STATUS, checkLogin);
-    yield takeLatest(Types.LOGOUT, logout);
-    yield takeEvery(Types.TRIGGER_OAUTH_LOGIN, triggerOAuthLogin);
+    yield takeEvery(CHANGE_DISPLAY_LOGIN_MODAL, handleFollowUpCancellation);
+    yield takeEvery(CHECK_LOGIN_STATUS, checkLogin);
+    yield takeLatest(LOGOUT, logout);
+    yield takeEvery(TRIGGER_OAUTH_LOGIN, triggerOAuthLogin);
 
     yield* handleOAuthRedirects();
     yield* checkLogin();

--- a/src/sagas/link-join-create.ts
+++ b/src/sagas/link-join-create.ts
@@ -1,8 +1,7 @@
 import { LOCATION_CHANGED } from '@festify/redux-little-router';
 import { put, select, take } from 'redux-saga/effects';
 
-import { Types } from '../actions';
-import { triggerOAuthLogin, NotifyAuthStatusKnownAction } from '../actions/auth';
+import { notifyAuthStatusKnown, triggerOAuthLogin, NOTIFY_AUTH_STATUS_KNOWN } from '../actions/auth';
 import { createPartyStart, joinPartyStart } from '../actions/party-data';
 import { changePartyId } from '../actions/view-home';
 import { State } from '../state';
@@ -22,7 +21,8 @@ export default function*() {
             return;
         }
         while (true) {
-            const { payload: authPayload }: NotifyAuthStatusKnownAction = yield take(Types.NOTIFY_AUTH_STATUS_KNOWN);
+            const { payload: authPayload }: ReturnType<typeof notifyAuthStatusKnown>
+                = yield take(NOTIFY_AUTH_STATUS_KNOWN);
             if (authPayload.provider === 'spotify' && !!authPayload.data) {
                 break;
             }

--- a/src/sagas/metadata.ts
+++ b/src/sagas/metadata.ts
@@ -3,14 +3,14 @@ import chunk from 'lodash-es/chunk';
 import { call, cancel, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import * as SpotifyApi from 'spotify-web-api-js';
 
-import { Types } from '../actions';
 import {
     getArtistFanart,
     getMusicBrainzId,
     updateMetadata,
     MetadataStore,
-    UpdateMetadataAction,
+    UPDATE_METADATA,
 } from '../actions/metadata';
+import { UPDATE_TRACKS } from '../actions/party-data';
 import { Views } from '../routing';
 import { loadFanartTracksSelector, loadMetadataSelector } from '../selectors/track';
 import { Metadata, State } from '../state';
@@ -20,7 +20,7 @@ import { fetchWithAnonymousAuth } from '../util/spotify-auth';
 const cache = new MetadataStore();
 
 let hasThrownIdbError = false;
-function* cacheMetadata(ac: UpdateMetadataAction) {
+function* cacheMetadata(ac: ReturnType<typeof updateMetadata>) {
     try {
         yield cache.cacheMetadata(ac.payload);
     } catch (err) {
@@ -68,7 +68,7 @@ function* watchTvMode(action, prevView: Views, newView: Views) {
 
     if (newView === Views.Tv) {
         loadFanartTask = yield takeLatest(
-            [Types.UPDATE_TRACKS, Types.UPDATE_METADATA],
+            [UPDATE_TRACKS, UPDATE_METADATA],
             loadFanartForNewTracks,
         );
 
@@ -117,8 +117,8 @@ function* loadMetadataForNewTracks(_) {
 }
 
 export default function*() {
-    yield takeEvery(Types.UPDATE_METADATA, cacheMetadata),
-    yield takeLatest(Types.UPDATE_TRACKS, loadMetadataForNewTracks),
+    yield takeEvery(UPDATE_METADATA, cacheMetadata),
+    yield takeLatest(UPDATE_TRACKS, loadMetadataForNewTracks),
     yield takeEveryWithState(
         LOCATION_CHANGED,
         (s: State) => (s.router!.result || { view: Views.Home }).view,

--- a/src/sagas/party-data.ts
+++ b/src/sagas/party-data.ts
@@ -4,8 +4,7 @@ import { DataSnapshot } from '@firebase/database-types';
 import { Channel } from 'redux-saga';
 import { all, call, cancel, fork, put, select, take, takeEvery } from 'redux-saga/effects';
 
-import { Types } from '../actions';
-import { NotifyAuthStatusKnownAction } from '../actions/auth';
+import { notifyAuthStatusKnown, NOTIFY_AUTH_STATUS_KNOWN } from '../actions/auth';
 import {
     becomePlaybackMaster,
     cleanupParty,
@@ -17,7 +16,8 @@ import {
     updateParty,
     updateTracks,
     updateUserVotes,
-    OpenPartyStartAction,
+    CLEANUP_PARTY,
+    OPEN_PARTY_START,
 } from '../actions/party-data';
 import { isPartyOwnerSelector, partyIdSelector } from '../selectors/party';
 import { ConnectionState, Party, State } from '../state';
@@ -83,7 +83,7 @@ function* loadParty() {
     };
 
     while (true) {
-        const { payload: id }: OpenPartyStartAction = yield take(Types.OPEN_PARTY_Start);
+        const { payload: id }: ReturnType<typeof openPartyStart> = yield take(OPEN_PARTY_START);
 
         const partyRef: Channel<DataSnapshot> = yield call(
             valuesChannel,
@@ -141,7 +141,7 @@ function* loadParty() {
 
         yield put(openPartyFinish(party));
 
-        yield take(Types.CLEANUP_PARTY);
+        yield take(CLEANUP_PARTY);
 
         yield cancel(partySettings, playbackManager, queueManager);
 
@@ -174,7 +174,7 @@ function* watchRoute() {
 
 function* watchLogin() {
     while (true) {
-        const ac: NotifyAuthStatusKnownAction = yield take(Types.NOTIFY_AUTH_STATUS_KNOWN);
+        const ac: ReturnType<typeof notifyAuthStatusKnown> = yield take(NOTIFY_AUTH_STATUS_KNOWN);
         const state: State = yield select();
         const partyId = partyIdSelector(state);
 

--- a/src/sagas/queue.ts
+++ b/src/sagas/queue.ts
@@ -1,14 +1,16 @@
 import { User } from '@firebase/auth-types';
 import { call, fork, put, select, take, takeEvery } from 'redux-saga/effects';
 
-import { showToast, Types } from '../actions';
+import { showToast } from '../actions';
+import { UPDATE_TRACKS } from '../actions/party-data';
 import {
     pinTrack,
     removeTrack as doRemoveTrack,
+    removeTrackAction,
     setVote as doSetVote,
     setVoteAction,
-    RemoveTrackAction,
-    SetVoteAction,
+    REMOVE_TRACK,
+    REQUEST_SET_VOTE,
 } from '../actions/queue';
 import { changeDisplayLoginModal } from '../actions/view-party';
 import { isPartyOwnerSelector, isPlaybackMasterSelector } from '../selectors/party';
@@ -25,7 +27,7 @@ function* pinTopTrack(partyId: string) {
     let topTrack: Track = undefined!;
 
     while (true) {
-        yield take(Types.UPDATE_TRACKS);
+        yield take(UPDATE_TRACKS);
 
         const state: State = yield select();
 
@@ -44,7 +46,7 @@ function* pinTopTrack(partyId: string) {
     }
 }
 
-function* removeTrack(partyId: string, ac: RemoveTrackAction) {
+function* removeTrack(partyId: string, ac: ReturnType<typeof removeTrackAction>) {
     try {
         const [ref, moveToHistory] = ac.payload;
         const state: State = yield select();
@@ -59,7 +61,7 @@ function* removeTrack(partyId: string, ac: RemoveTrackAction) {
     }
 }
 
-function* setVote(partyId: string, ac: SetVoteAction) {
+function* setVote(partyId: string, ac: ReturnType<typeof setVoteAction>) {
     const { party }: State = yield select();
     if (party.currentParty!.settings && !party.currentParty!.settings!.allow_anonymous_voters) {
         const user: User = yield call(requireAuth);
@@ -79,7 +81,7 @@ function* setVote(partyId: string, ac: SetVoteAction) {
 }
 
 export default function*(partyId: string) {
-    yield takeEvery(Types.REMOVE_TRACK, removeTrack, partyId);
-    yield takeEvery(Types.REQUEST_SET_VOTE, setVote, partyId);
+    yield takeEvery(REMOVE_TRACK, removeTrack, partyId);
+    yield takeEvery(REQUEST_SET_VOTE, setVote, partyId);
     yield fork(pinTopTrack, partyId);
 }

--- a/src/sagas/toast.ts
+++ b/src/sagas/toast.ts
@@ -1,28 +1,38 @@
 import { delay } from 'redux-saga';
 import { all, call, put, takeEvery, takeLatest } from 'redux-saga/effects';
 
-import { hideToast, showToast, ShowToastAction, Types } from '../actions';
-import { ExchangeCodeFailAction } from '../actions/auth';
-import { CreatePartyFailAction, JoinPartyFailAction, OpenPartyFailAction } from '../actions/party-data';
-import { PlayerErrorAction, TogglePlaybackFailAction } from '../actions/playback-spotify';
+import { hideToast, showToast, SHOW_TOAST } from '../actions';
+import { exchangeCodeFail, EXCHANGE_CODE_FAIL } from '../actions/auth';
 import {
-    FlushQueueFailAction,
-    InsertFallbackPlaylistFailAction,
-    LoadPlaylistsFailAction,
+    createPartyFail,
+    joinPartyFail,
+    openPartyFail,
+    CREATE_PARTY_FAIL,
+    JOIN_PARTY_FAIL,
+    OPEN_PARTY_FAIL,
+} from '../actions/party-data';
+import { playerError, togglePlaybackFail, PLAYER_ERROR, TOGGLE_PLAYBACK_FAIL } from '../actions/playback-spotify';
+import {
+    flushQueueFail,
+    insertPlaylistFail,
+    loadPlaylistsFail,
+    FLUSH_QUEUE_FAIL,
+    INSERT_FALLBACK_PLAYLIST_FAIL,
+    LOAD_PLAYLISTS_FAIL,
 } from '../actions/view-party-settings';
 
 type ErrorActions =
-    | CreatePartyFailAction
-    | ExchangeCodeFailAction
-    | FlushQueueFailAction
-    | InsertFallbackPlaylistFailAction
-    | JoinPartyFailAction
-    | LoadPlaylistsFailAction
-    | OpenPartyFailAction
-    | PlayerErrorAction
-    | TogglePlaybackFailAction;
+    | ReturnType<typeof createPartyFail>
+    | ReturnType<typeof exchangeCodeFail>
+    | ReturnType<typeof flushQueueFail>
+    | ReturnType<typeof insertPlaylistFail>
+    | ReturnType<typeof joinPartyFail>
+    | ReturnType<typeof loadPlaylistsFail>
+    | ReturnType<typeof openPartyFail>
+    | ReturnType<typeof playerError>
+    | ReturnType<typeof togglePlaybackFail>;
 
-function* displayToast(action: ShowToastAction) {
+function* displayToast(action: ReturnType<typeof showToast>) {
     if (!Number.isFinite(action.payload.duration)) {
         return;
     }
@@ -33,7 +43,7 @@ function* displayToast(action: ShowToastAction) {
 
 function* displayErrorToast(action: ErrorActions) {
     yield put(showToast(
-        (action.type === Types.EXCHANGE_CODE_Fail)
+        (action.type === EXCHANGE_CODE_FAIL)
             ? action.payload.data.message
             : action.payload.message,
         10000,
@@ -42,17 +52,17 @@ function* displayErrorToast(action: ErrorActions) {
 
 export default function*() {
     yield all([
-        takeLatest(Types.SHOW_TOAST, displayToast),
+        takeLatest(SHOW_TOAST, displayToast),
         takeEvery([
-            Types.CREATE_PARTY_Fail,
-            Types.EXCHANGE_CODE_Fail,
-            Types.FLUSH_QUEUE_Fail,
-            Types.INSERT_FALLBACK_PLAYLIST_Fail,
-            Types.JOIN_PARTY_Fail,
-            Types.LOAD_PLAYLISTS_Fail,
-            Types.OPEN_PARTY_Fail,
-            Types.PLAYER_ERROR,
-            Types.TOGGLE_PLAYBACK_Fail,
+            CREATE_PARTY_FAIL,
+            EXCHANGE_CODE_FAIL,
+            FLUSH_QUEUE_FAIL,
+            INSERT_FALLBACK_PLAYLIST_FAIL,
+            JOIN_PARTY_FAIL,
+            LOAD_PLAYLISTS_FAIL,
+            OPEN_PARTY_FAIL,
+            PLAYER_ERROR,
+            TOGGLE_PLAYBACK_FAIL,
         ], displayErrorToast),
     ]);
 }

--- a/src/sagas/view-home.ts
+++ b/src/sagas/view-home.ts
@@ -1,13 +1,16 @@
 import { push } from '@festify/redux-little-router';
 import { call, put, select, takeLatest } from 'redux-saga/effects';
 
-import { showToast, Types } from '../actions';
+import { showToast } from '../actions';
+import { NOTIFY_AUTH_STATUS_KNOWN } from '../actions/auth';
 import {
     createNewParty,
     createPartyFail,
     joinPartyFail,
+    joinPartyStart,
     resolveShortId,
-    JoinPartyStartAction,
+    CREATE_PARTY_START,
+    JOIN_PARTY_START,
 } from '../actions/party-data';
 import { Views } from '../routing';
 import { PartySettings, State } from '../state';
@@ -40,7 +43,7 @@ function* createParty() {
     yield put(push(`/party/${partyId}`));
 }
 
-function* joinParty(ac: JoinPartyStartAction) {
+function* joinParty(ac: ReturnType<typeof joinPartyStart>) {
     const { homeView }: State = yield select();
 
     if (!homeView.partyIdValid) {
@@ -76,7 +79,7 @@ function* warnNonPremium() {
 }
 
 export default function*() {
-    yield takeLatest(Types.NOTIFY_AUTH_STATUS_KNOWN, warnNonPremium);
-    yield takeLatest(Types.CREATE_PARTY_Start, createParty);
-    yield takeLatest(Types.JOIN_PARTY_Start, joinParty);
+    yield takeLatest(NOTIFY_AUTH_STATUS_KNOWN, warnNonPremium);
+    yield takeLatest(CREATE_PARTY_START, createParty);
+    yield takeLatest(JOIN_PARTY_START, joinParty);
 }

--- a/src/sagas/view-party-queue.ts
+++ b/src/sagas/view-party-queue.ts
@@ -1,21 +1,28 @@
 import { delay } from 'redux-saga';
 import { put, takeEvery } from 'redux-saga/effects';
 
-import { QueueDragEnterAction, Types } from '../actions';
+import {
+    queueDragDrop,
+    queueDragEnter,
+    queueDragOver,
+    QUEUE_DRAG_DROP,
+    QUEUE_DRAG_ENTER,
+    QUEUE_DRAG_OVER,
+} from '../actions';
 import { setVoteAction } from '../actions/queue';
 
 export default function*() {
-    yield takeEvery(Types.QUEUE_DRAG_Over, (event: QueueDragEnterAction) => {
+    yield takeEvery(QUEUE_DRAG_OVER, (event: ReturnType<typeof queueDragOver>) => {
         event.payload.event.preventDefault();
     });
 
-    yield takeEvery(Types.QUEUE_DRAG_Enter, (event: QueueDragEnterAction) => {
+    yield takeEvery(QUEUE_DRAG_ENTER, (event: ReturnType<typeof queueDragEnter>) => {
         event.payload.event.returnValue = false;
         event.payload.event.dataTransfer.dropEffect = "copy";
         event.payload.event.preventDefault();
     });
 
-    yield takeEvery(Types.QUEUE_DRAG_Drop, function*(event: QueueDragEnterAction) {
+    yield takeEvery(QUEUE_DRAG_DROP, function*(event: ReturnType<typeof queueDragDrop>) {
         event.payload.event.preventDefault();
         const data: string = event.payload.event.dataTransfer.getData("text/plain");
         const trackRegex = /\/track\/([0-9a-z]+)/gi;

--- a/src/sagas/view-party-search.ts
+++ b/src/sagas/view-party-search.ts
@@ -2,10 +2,16 @@ import { push, replace, LOCATION_CHANGED } from '@festify/redux-little-router';
 import { delay } from 'redux-saga';
 import { call, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 
-import { Types } from '../actions';
 import { updateMetadata } from '../actions/metadata';
-import { SetVoteAction } from '../actions/queue';
-import { searchFail, searchFinish, searchStart, ChangeTrackSearchInputAction } from '../actions/view-party';
+import { UPDATE_PARTY } from '../actions/party-data';
+import { setVoteAction, SET_VOTE } from '../actions/queue';
+import {
+    changeTrackSearchInput,
+    searchFail,
+    searchFinish,
+    searchStart,
+    CHANGE_TRACK_SEARCH_INPUT,
+} from '../actions/view-party';
 import { PartyViews } from '../routing';
 import { queueRouteSelector, searchRouteSelector } from '../selectors/routes';
 import { State, Track } from '../state';
@@ -14,7 +20,7 @@ import { fetchWithAnonymousAuth } from '../util/spotify-auth';
 function* doSearch(action) {
     const { party }: State = yield select();
     if (!party.currentParty) {
-        yield take(Types.UPDATE_PARTY);
+        yield take(UPDATE_PARTY);
     }
 
     const { query: { s } } = action.payload || { query: { s: '' } };
@@ -70,7 +76,7 @@ function* doSearch(action) {
     yield put(searchFinish(result));
 }
 
-function* enforceMultiVoteSetting(ac: SetVoteAction) {
+function* enforceMultiVoteSetting(ac: ReturnType<typeof setVoteAction>) {
     const state: State = yield select();
     if (!state.party.currentParty || !state.party.currentParty.settings) {
         return;
@@ -84,7 +90,7 @@ function* enforceMultiVoteSetting(ac: SetVoteAction) {
     }
 }
 
-function* updateUrl(action: ChangeTrackSearchInputAction) {
+function* updateUrl(action: ReturnType<typeof changeTrackSearchInput>) {
     const state: State = yield select();
     const { s } = state.router!.query || { s: '' };
 
@@ -101,6 +107,6 @@ function* updateUrl(action: ChangeTrackSearchInputAction) {
 
 export default function*() {
     yield takeLatest(LOCATION_CHANGED, doSearch);
-    yield takeEvery(Types.CHANGE_TRACK_SEARCH_INPUT, updateUrl);
-    yield takeEvery(Types.SET_VOTE, enforceMultiVoteSetting);
+    yield takeEvery(CHANGE_TRACK_SEARCH_INPUT, updateUrl);
+    yield takeEvery(SET_VOTE, enforceMultiVoteSetting);
 }

--- a/src/sagas/view-party-settings.ts
+++ b/src/sagas/view-party-settings.ts
@@ -2,8 +2,10 @@ import { LOCATION_CHANGED } from '@festify/redux-little-router';
 import { buffers, eventChannel, Channel, END } from 'redux-saga';
 import { call, put, select, take, takeLatest } from 'redux-saga/effects';
 
-import { Types } from '../actions';
+import { NOTIFY_AUTH_STATUS_KNOWN } from '../actions/auth';
 import {
+    changePartyName as updatePartyNameAction,
+    changePartySetting as changePartySettingAction,
     flushQueue,
     flushQueueFail,
     flushQueueFinish,
@@ -11,22 +13,24 @@ import {
     insertPlaylistFail,
     insertPlaylistFinish,
     insertPlaylistProgress,
+    insertPlaylistStart,
     loadPlaylists,
     loadPlaylistsFail,
     loadPlaylistsStart,
     updateUserPlaylists,
-    ChangePartySettingAction,
-    InsertFallbackPlaylistStartAction,
-    UpdatePartyNameAction,
+    CHANGE_PARTY_SETTING,
+    FLUSH_QUEUE_START,
+    INSERT_FALLBACK_PLAYLIST_START,
+    UPDATE_PARTY_NAME,
 } from '../actions/view-party-settings';
 import { PartyViews } from '../routing';
 import { isPartyOwnerSelector } from '../selectors/party';
 import { queueTracksSelector } from '../selectors/track';
 import { hasConnectedSpotifyAccountSelector } from '../selectors/users';
-import { PartySettings, Playlist, State, Track } from '../state';
+import { Playlist, State, Track } from '../state';
 import firebase from '../util/firebase';
 
-function* changePartySetting(partyId: string, ac: ChangePartySettingAction<keyof PartySettings>) {
+function* changePartySetting(partyId: string, ac: ReturnType<typeof changePartySettingAction>) {
     if (!(yield select(isPartyOwnerSelector))) {
         return;
     }
@@ -68,7 +72,7 @@ function* flushTracks(partyId: string) {
     }
 }
 
-function* insertPlaylist(partyId: string, ac: InsertFallbackPlaylistStartAction) {
+function* insertPlaylist(partyId: string, ac: ReturnType<typeof insertPlaylistStart>) {
     type SubActions =
         | { type: 'progress', payload: number }
         | { type: 'error', payload: Error }
@@ -107,7 +111,7 @@ function* insertPlaylist(partyId: string, ac: InsertFallbackPlaylistStartAction)
     }
 }
 
-function* updatePartyName(partyId: string, ac: UpdatePartyNameAction) {
+function* updatePartyName(partyId: string, ac: ReturnType<typeof updatePartyNameAction>) {
     yield firebase.database!()
         .ref('/parties')
         .child(partyId)
@@ -116,15 +120,15 @@ function* updatePartyName(partyId: string, ac: UpdatePartyNameAction) {
 }
 
 export function* managePartySettings(partyId: string) {
-    yield takeLatest(Types.CHANGE_PARTY_SETTING, changePartySetting, partyId);
-    yield takeLatest(Types.FLUSH_QUEUE_Start, flushTracks, partyId);
-    yield takeLatest(Types.INSERT_FALLBACK_PLAYLIST_Start, insertPlaylist, partyId);
-    yield takeLatest(Types.UPDATE_PARTY_NAME, updatePartyName, partyId);
+    yield takeLatest(CHANGE_PARTY_SETTING, changePartySetting, partyId);
+    yield takeLatest(FLUSH_QUEUE_START, flushTracks, partyId);
+    yield takeLatest(INSERT_FALLBACK_PLAYLIST_START, insertPlaylist, partyId);
+    yield takeLatest(UPDATE_PARTY_NAME, updatePartyName, partyId);
 }
 
 export default function*() {
     yield takeLatest([
-        Types.NOTIFY_AUTH_STATUS_KNOWN,
+        NOTIFY_AUTH_STATUS_KNOWN,
         LOCATION_CHANGED,
     ], fetchPlaylists);
 }

--- a/src/sagas/view-party-share.ts
+++ b/src/sagas/view-party-share.ts
@@ -1,6 +1,6 @@
 import { call, select, takeEvery } from 'redux-saga/effects';
 
-import { Types } from '../actions';
+import { SHARE_PARTY } from '../actions/view-party-share';
 import { partyIdSelector } from '../selectors/party';
 import { State } from '../state';
 
@@ -29,5 +29,5 @@ export default function*() {
         return;
     }
 
-    yield takeEvery(Types.SHARE_PARTY, share);
+    yield takeEvery(SHARE_PARTY, share);
 }


### PR DESCRIPTION
We now use the return type of an action creator as base for the discriminated union instead of manually declaring the interface and then the action creator.

This PR is there so I can see the size difference from bundlesize.