### PR TITLE
Removed birthdate scope from spotify authentication.

### DIFF
--- a/src/util/spotify-auth.ts
+++ b/src/util/spotify-auth.ts
@@ -8,7 +8,6 @@ export const SCOPES = [
     "streaming",
     "user-modify-playback-state",
     "user-read-playback-state",
-    "user-read-birthdate",
     "user-read-email",
     "user-read-private",
     "playlist-read-collaborative",


### PR DESCRIPTION
Removed the user-read-birthdate scrope from Spotify authentication because it is deprecated.