### PR TITLE
Fix the share url

### DIFF
--- a/src/sagas/view-party-share.ts
+++ b/src/sagas/view-party-share.ts
@@ -19,7 +19,7 @@ function* share() {
     yield call((navigator as any).share, {
         text: `Join ${currentParty.name} and rule the music!`,
         title: currentParty.name,
-        url: `${document.location!.origin}/party/${partyId}`,
+        url: `${document.location!.origin}/${partyId}`,
     });
 }
 


### PR DESCRIPTION
This PR only changes the share url by removing the /party path.

Why?
Short: The link adding the party code and not the partyId. So festify.us/party/xxxxxx could not be found.

Detailed:
The variable `partyId` has two meanings inside the project. On the one hand the partyId describes the unique Id of a party and on the other hand it stands for the party code to join an existing party.

There should be a separation into partyId and partyCode over the project. Does it make sense to implement this directly with this request?